### PR TITLE
Addresses issue #5 - Lights reverting to 1% brightness when turned off with transitiontime

### DIFF
--- a/devicetypes/info-fiend/hue-b-smart-ambiance-bulb.src/hue-b-smart-ambiance-bulb.groovy
+++ b/devicetypes/info-fiend/hue-b-smart-ambiance-bulb.src/hue-b-smart-ambiance-bulb.groovy
@@ -313,7 +313,8 @@ def off() {
 	        headers: [
 	        	host: "${commandData.ip}"
 			],
-	        body: [on: false, transitiontime: tt]
+	        //body: [on: false, transitiontime: tt] # Sending transitiontime with on: false sometimes results in bri level at 1 when on: true sent outside of app
+		body: [on: false]
 		])
 }
 

--- a/devicetypes/info-fiend/hue-b-smart-bulb.src/hue-b-smart-bulb.groovy
+++ b/devicetypes/info-fiend/hue-b-smart-bulb.src/hue-b-smart-bulb.groovy
@@ -501,7 +501,8 @@ def off() {
 	        headers: [
 	        	host: "${commandData.ip}"
 			],
-	        body: [on: false, transitiontime: tt]
+	        //body: [on: false, transitiontime: tt] # Sending transitiontime with on: false sometimes results in bri level at 1 when on: true sent outside of app
+		body: [on: false]
 		])
 //	)
 }

--- a/devicetypes/info-fiend/hue-b-smart-group.src/hue-b-smart-group.groovy
+++ b/devicetypes/info-fiend/hue-b-smart-group.src/hue-b-smart-group.groovy
@@ -513,7 +513,8 @@ def off() {
 	        headers: [
 	        	host: "${commandData.ip}"
 			],
-	        body: [on: false, transitiontime: tt]
+	        //body: [on: false, transitiontime: tt] # Sending transitiontime with on: false sometimes results in bri level at 1 when on: true sent outside of app
+		body: [on: false]
 		])
 //	)
      //   sendEvent(name: "switch", value: off, isStateChange: true, displayed: true)

--- a/devicetypes/info-fiend/hue-b-smart-lux-bulb.src/hue-b-smart-lux-bulb.groovy
+++ b/devicetypes/info-fiend/hue-b-smart-lux-bulb.src/hue-b-smart-lux-bulb.groovy
@@ -198,7 +198,8 @@ def off() {
 	        headers: [
 	        	host: "${commandData.ip}"
 			],
-	        body: [on: false, transitiontime: tt]
+	        //body: [on: false, transitiontime: tt] # Sending transitiontime with on: false sometimes results in bri level at 1 when on: true sent outside of app
+		body: [on: false]
 		])
 //	)
 }

--- a/devicetypes/info-fiend/hue-b-smart-lux-group.src/hue-b-smart-lux-group.groovy
+++ b/devicetypes/info-fiend/hue-b-smart-lux-group.src/hue-b-smart-lux-group.groovy
@@ -199,7 +199,8 @@ def off() {
 	        headers: [
 	        	host: "${commandData.ip}"
 			],
-	        body: [on: false, transitiontime: tt]
+	        //body: [on: false, transitiontime: tt] # Sending transitiontime with on: false sometimes results in bri level at 1 when on: true sent outside of app
+		body: [on: false]
 		])
 //	)
 }

--- a/devicetypes/info-fiend/hue-b-smart-white-ambiance.src/hue-b-smart-white-ambiance.groovy
+++ b/devicetypes/info-fiend/hue-b-smart-white-ambiance.src/hue-b-smart-white-ambiance.groovy
@@ -315,7 +315,8 @@ def off() {
 	        headers: [
 	        	host: "${commandData.ip}"
 			],
-	        body: [on: false, transitiontime: tt]
+	        //body: [on: false, transitiontime: tt] # Sending transitiontime with on: false sometimes results in bri level at 1 when on: true sent outside of app
+		body: [on: false]
 		])
 }
 


### PR DESCRIPTION
These fixes address the problem where lights come on at 1% brightness when using secondary control like Philips Hue app or Homekit after being turned off through Hue B Smart. This is my first ever GitHub pull request, so I apologize if I did it wrong. 