### PR TITLE
Correct saturation problem with setting various SmartThings colors

### DIFF
--- a/devicetypes/info-fiend/hue-b-smart-bulb.src/hue-b-smart-bulb.groovy
+++ b/devicetypes/info-fiend/hue-b-smart-bulb.src/hue-b-smart-bulb.groovy
@@ -873,7 +873,7 @@ private colorFromHSB (h, s, level) {
 	
     // Ranges are 0-360 for Hue, 0-1 for Sat and Bri
     def hue = (h * 360 / 100).toInteger()
-    def sat = (s / 100).toInteger()
+    def sat = (s / 100)	//.toInteger()
     def bri = (level / 100)	//.toInteger()
 //	log.debug "hue = ${hue} / sat = ${sat} / bri = ${bri}"
     float i = Math.floor(hue / 60) % 6;


### PR DESCRIPTION
This fixes the transform error that causes a majority of SmartThings colors to change to white.